### PR TITLE
Use cross-spawn to spawn elm-make

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var url = require('url');
 var path = require('path');
 var child_process = require('child_process');
+var cross_spawn = require('cross-spawn');
 var make = require.resolve('elm/binwrappers/elm-make');
 
 class ElmLangCompiler {
@@ -30,7 +31,7 @@ class ElmLangCompiler {
     _compile (file, module) {
         let output = path.join(this.config.output, module + '.js');
         
-        child_process.execFileSync(make, this.config.parameters.concat([
+        cross_spawn.sync(make, this.config.parameters.concat([
             '--output', output, file.path
         ]));
 

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class ElmLangCompiler {
             document.body.style.backgroundColor = "#000";
             module.exports.Errors.fullscreen(\`${escaped}\`);`;
             
-        child_process.execFileSync(make, this.config.parameters.concat([
+        cross_spawn.sync(make, this.config.parameters.concat([
             '--output', output, errorFile
         ]));
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ class ElmLangCompiler {
         ]));
 
         if (result.status) {
-            throw (result.error || new Error('elm-make returned non-zero status code ' + error.status));
+            throw (result.error || new Error('elm-make returned non-zero status code ' + result.status));
         }
 
         return fs.readFileSync(output, 'utf8');

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 var fs = require('fs');
 var url = require('url');
 var path = require('path');
-var child_process = require('child_process');
 var cross_spawn = require('cross-spawn');
 var make = require.resolve('elm/binwrappers/elm-make');
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "node_modules/.bin/eslint index.js test.js && node_modules/.bin/mocha"
   },
   "dependencies": {
+    "cross-spawn": "^5.1.0",
     "elm": "^0.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The builtin child_process module does not work properly for cross-platform packages, specified in issue #6. Using cross-spawn to spawn elm-make allows brunch to compile Elm files on Windows.

I have tested this change on my Windows machine and after making the change, the plugin works as expected.